### PR TITLE
fix possible CUDA BUG

### DIFF
--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -38,7 +38,7 @@ class CachedMNIST(Dataset):
             self._cache[index] = list(self.ds[index])
             if self.cuda:
                 self._cache[index][0] = self._cache[index][0].cuda(non_blocking=True)
-                self._cache[index][1] = self._cache[index][1].cuda(non_blocking=True)
+                self._cache[index][1] = torch.tensor(self._cache[index][1], dtype = torch.long).cuda(non_blocking=True)
         return self._cache[index]
 
     def __len__(self) -> int:


### PR DESCRIPTION
If we run python mnist.py --cuda True
The details of bug is :   File "mnist.py", line 41, in __getitem__
    self._cache[index][1] = self._cache[index][1].cuda(non_blocking=True)
AttributeError: 'int' object has no attribute 'cuda'